### PR TITLE
fix: Playwright configをシンプル化してE2Eテストを安定化

### DIFF
--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -22,7 +22,9 @@ export default defineConfig({
     baseURL,
     headless: true,
     launchOptions: {
-      executablePath: getEnv("PLAYWRIGHT_CHROMIUM_EXECUTABLE_PATH"),
+      ...(getEnv("PLAYWRIGHT_CHROMIUM_EXECUTABLE_PATH")
+        ? { executablePath: getEnv("PLAYWRIGHT_CHROMIUM_EXECUTABLE_PATH") }
+        : {}),
       args: ["--no-sandbox"],
     },
   },


### PR DESCRIPTION
## Summary

- Chromiumの新headlessモードがReact 19のイベント委譲と互換性問題を持つことを検証で特定
- Playwrightのデフォルト動作（`channel`未指定 = headless shell使用）に任せるよう `playwright.config.ts` をシンプル化
- `executablePath` は `PLAYWRIGHT_CHROMIUM_EXECUTABLE_PATH` 環境変数指定時のみ設定

### 原因分析

| 実験 | 結果 |
|------|------|
| chromium (new headless) でPlaywrightクリック | React `onClick` に到達しない |
| chromium_headless_shell でPlaywrightクリック | 正常動作 |
| JS直接 `element.click()` | 正常動作 |
| 実ブラウザ | 正常動作 |

Playwright公式ドキュメントに従い、`channel`を指定せずデフォルトのheadless shellに任せる方針を採用。

## Test plan

- [x] E2Eテスト全件PASS（76 passed, 1 skipped）
- [x] rebase on main 済み

https://claude.ai/code/session_01UHX8hKh1iePr18AKcwbm2H