### PR TITLE
fix: make cloudflare vite plugin conditional to fix CI

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,8 +7,8 @@
     "dev": "vp dev",
     "build": "tsc -b && vp build",
     "lint": "eslint .",
-    "preview": "pnpm run build && wrangler dev",
-    "deploy": "pnpm run build && wrangler deploy"
+    "preview": "CLOUDFLARE=1 pnpm run build && wrangler dev",
+    "deploy": "CLOUDFLARE=1 pnpm run build && wrangler deploy"
   },
   "dependencies": {
     "@base-ui/react": "^1.3.0",

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -1,13 +1,19 @@
 import { defineConfig } from "vite-plus";
 import react from "@vitejs/plugin-react";
 import tailwindcss from "@tailwindcss/vite";
+import type { PluginOption } from "vite";
 
-import { cloudflare } from "@cloudflare/vite-plugin";
+const plugins: PluginOption[] = [tailwindcss(), react()];
+
+if (process.env.CLOUDFLARE) {
+  const { cloudflare } = await import("@cloudflare/vite-plugin");
+  plugins.push(cloudflare());
+}
 
 export default defineConfig({
   base: process.env.VITE_BASE_PATH || "/kalendar/",
   lint: { options: { typeAware: true, typeCheck: true } },
-  plugins: [tailwindcss(), react(), cloudflare()],
+  plugins,
   resolve: {
     alias: {
       "@": "/src",

--- a/wrangler.jsonc
+++ b/wrangler.jsonc
@@ -3,12 +3,10 @@
   "name": "kalendar",
   "compatibility_date": "2025-09-27",
   "observability": {
-    "enabled": true
+    "enabled": true,
   },
   "assets": {
-    "not_found_handling": "single-page-application"
+    "not_found_handling": "single-page-application",
   },
-  "compatibility_flags": [
-    "nodejs_compat"
-  ]
+  "compatibility_flags": ["nodejs_compat"],
 }


### PR DESCRIPTION
The cloudflare() plugin was imported unconditionally in vite.config.ts, breaking CI workflows that build for GitHub Pages (not Cloudflare Workers). Now the plugin is only loaded when CLOUDFLARE env var is set.

https://claude.ai/code/session_01UyQjUXiTDhoftjWoNRDKh2