### PR TITLE
fix: add assets directory to wrangler config for Cloudflare deploy

### DIFF
--- a/wrangler.jsonc
+++ b/wrangler.jsonc
@@ -6,6 +6,7 @@
     "enabled": true,
   },
   "assets": {
+    "directory": "./dist",
     "not_found_handling": "single-page-application",
   },
   "compatibility_flags": ["nodejs_compat"],


### PR DESCRIPTION
The wrangler.jsonc was missing the required `directory` property in the `assets` config, causing `wrangler versions upload` to fail with: "The assets property is missing the required directory property."

https://claude.ai/code/session_01UyQjUXiTDhoftjWoNRDKh2