### PR TITLE
fix: switch default base path to / for Cloudflare Pages

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -33,6 +33,8 @@ jobs:
 
       - name: Build
         run: pnpm run build
+        env:
+          VITE_BASE_PATH: /kalendar/
 
       - name: E2E Test
         run: pnpm exec playwright test --ignore-snapshots

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -11,7 +11,7 @@ if (process.env.CLOUDFLARE) {
 }
 
 export default defineConfig({
-  base: process.env.VITE_BASE_PATH || "/kalendar/",
+  base: process.env.VITE_BASE_PATH || "/",
   lint: { options: { typeAware: true, typeCheck: true } },
   plugins,
   resolve: {


### PR DESCRIPTION
The default base path was /kalendar/ (for GitHub Pages), causing asset 404s on Cloudflare Pages which serves from root /. Changed default to / and set VITE_BASE_PATH=/kalendar/ explicitly in the GitHub Pages deploy workflow.

https://claude.ai/code/session_01UyQjUXiTDhoftjWoNRDKh2